### PR TITLE
Updating gunicorn command and worker class

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,6 +11,8 @@ click==8.1.7
 feedparser==6.0.11
 Flask==3.0.3
 Flask-Caching==2.3.0
+gevent==24.2.1
+greenlet==3.1.1
 gunicorn==22.0.0
 idna==3.7
 importlib_metadata==7.1.0
@@ -31,6 +33,7 @@ python-dotenv==1.0.1
 requests==2.31.0
 rich==13.8.0
 s3transfer==0.10.2
+setuptools==75.1.0
 sgmllib3k==1.0.0
 shellingham==1.5.4
 six==1.16.0
@@ -41,3 +44,5 @@ typing_extensions==4.11.0
 urllib3==2.2.1
 Werkzeug==3.0.3
 zipp==3.18.1
+zope.event==5.0
+zope.interface==7.0.3

--- a/render.yaml
+++ b/render.yaml
@@ -31,7 +31,7 @@ services:
       value: 3.12.3
     region: ohio
     buildCommand: pip install -r requirements.txt
-    startCommand: gunicorn app:app -t 60 --keep-alive 60
+    startCommand: gunicorn --workers=1 --worker-class=gevent app:app -t 60 --keep-alive 60
     rootDir: backend
     pullRequestPreviewsEnabled: true
 


### PR DESCRIPTION
In preparing for more usage in production, I researched how to best configure my gunicorn command based on my application design. Because this is primarily network I/O bound (parsing RSS feeds, making external web calls, etc.), there is an added benefit to using the gevent worker class. Gevent workers provide async concurrency without needing to explicitly rewrite your code to be async due to how it can monkey-patch common I/O bound operations.