### PR TITLE
Fix monkey-patching issue introduced by gevent change

### DIFF
--- a/backend/geventlet-config.py
+++ b/backend/geventlet-config.py
@@ -1,0 +1,5 @@
+try:
+    import gevent.monkey
+    gevent.monkey.patch_all()
+except ImportError:
+    pass

--- a/render.yaml
+++ b/render.yaml
@@ -31,7 +31,7 @@ services:
       value: 3.12.3
     region: ohio
     buildCommand: pip install -r requirements.txt
-    startCommand: gunicorn --workers=1 --worker-class=gevent app:app -t 60 --keep-alive 60
+    startCommand: gunicorn --config geventlet-config.py --workers=1 --worker-class=gevent app:app -t 60 --keep-alive 60
     rootDir: backend
     pullRequestPreviewsEnabled: true
 


### PR DESCRIPTION
Updating to a gevent worker class for gunicorn caused the app to fail on its api requests. It threw a maximum recursion depth exceeded, and this was a warning produced at the top of the logs as well. Resolved by using the solution referenced here: https://github.com/benoitc/gunicorn/issues/2796#issuecomment-2168555670