### PR TITLE
Fixed the daily cumulative sum chart

### DIFF
--- a/analytics/migrations/20250115181138_fix_daily_cumulative_sum_view.sql
+++ b/analytics/migrations/20250115181138_fix_daily_cumulative_sum_view.sql
@@ -1,0 +1,40 @@
+DROP VIEW cumulative_shelf_counts_daily;
+
+CREATE VIEW cumulative_shelf_counts_daily AS
+WITH
+  interval_series AS (
+    SELECT
+      GENERATE_SERIES(
+        DATE_TRUNC('day', (SELECT current_date - INTERVAL '90 day')),
+        DATE_TRUNC('day', CURRENT_DATE),
+        '1 day'::INTERVAL
+      ) AS date_interval
+  ),
+  shelf_counts AS (
+    SELECT
+      DATE_TRUNC('day', s.date_added) AS date,
+      COUNT(s.shelf_id) AS shelf_count
+    FROM shelves s
+    GROUP BY
+    1
+  ),
+  shelf_count_offset AS (
+    SELECT
+      SUM(shelf_count) AS count_offset
+      FROM shelf_counts
+      WHERE
+      date <= (SELECT current_date - INTERVAL '90 day')
+  )
+  SELECT
+    TO_CHAR(i.date_interval, 'YYYY-MM-DD') AS date,
+    TO_CHAR(i.date_interval, 'MON DD') AS date_axis,
+    COALESCE(sc.shelf_count, 0) AS shelf_count,
+    SUM(COALESCE(sc.shelf_count, 0)) OVER (
+      ORDER BY
+      i.date_interval
+    ) + (SELECT count_offset FROM shelf_count_offset) AS "Cumulative Shelf Count"
+  FROM interval_series i
+    LEFT JOIN shelf_counts sc
+      ON i.date_interval = sc.date
+  ORDER BY
+    i.date_interval

--- a/analytics/migrations/atlas.sum
+++ b/analytics/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:y+avhD/mzrnA4KoktPj5skwgwLYzjhljFaZQ2edatlg=
+h1:OEKerzICdJr4Sf06U6SpZy4mjXDQ9G9/H2QzAsK6mQ8=
 20240902163052_initial_schema.sql h1:sZ5S9H+um8NH935kCVqOncqGoe4frzKLgXjBX67Dibs=
 20240902163111_seed_libraries.sql h1:wgak9bWfYKTLW0R1aLpIT7bkCteBTCj6RioFB1f1erE=
 20240904215325_enable_rls.sql h1:0Usmn6sD3tyl5QLAr39mZ2hrbQJiMjchuMDmIa7+nGI=
@@ -9,3 +9,4 @@ h1:y+avhD/mzrnA4KoktPj5skwgwLYzjhljFaZQ2edatlg=
 20240925153823_populate_search_type.sql h1:p1kS+dW/pdTuxpWemGO8M+mERzhVEsYyNRj2B9bd5aQ=
 20240926014002_add_total_search_type_view.sql h1:/dZGiaLYBNx7TG9GnNw00QSbegjWZytTHYpEX5Pk52A=
 20241029221340_add_new_libraries.sql h1:/vTxFBaH8XWxWS7VDUTWnXcHM1JNkL+kq+Px4R23vhw=
+20250115181138_fix_daily_cumulative_sum_view.sql h1:WrwIz4XTGFaXLUhWH2FAJmoHNhZoUSA35/Hr9BbYNwA=


### PR DESCRIPTION
Added an offset to the results so that the total cumulative sum matches the full total. This way the rolling 90-day window matches correctly with the grand total, while also limiting the number of records to the front end instead of pulling from all time.